### PR TITLE
[FEATURE] Null-safe field assign

### DIFF
--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -823,25 +823,37 @@ class Parser {
 		case TQuestionDot:
 			var field = getIdent();
 			var tmp = "__a_" + (uid++);
+			var t = token();
+			inline function pushBack() { push(t); return null; }
+			var eOp = switch (t) {
+				case TOp(s): if (!opRightAssoc.exists(s)) pushBack(); else s;
+				case TPOpen: '';
+				default: pushBack();
+			}
+
+			if (eOp != null && eOp.length > 0) {
+				var e2 = parseExpr();
+				var e = 
+					mk(EBlock([
+						mk(EVar(tmp, null, e1)),
+						mk(ETernary(
+						mk(EBinop("!=", mk(EIdent(tmp), pmin(e1), pmax(e1)), mk(EIdent("null"), pmin(e1), pmax(e1))), pmin(e1), pmax(e1)),
+						mk(EBinop(eOp, mk(EField(mk(EIdent(tmp), pmin(e1), pmax(e1)),field), pmin(e1), pmax(e1)), e2), pmin(e1), pmax(e2)),
+						mk(EIdent("null"), pmin(e2), pmax(e2))),
+						pmin(e1), pmax(e2))
+				]), pmin(e1));
+				return parseExprNext(e);
+			}
+
 			var e = mk(EBlock([
 				mk(EVar(tmp, null, e1), pmin(e1), pmax(e1)),
 				mk(ETernary(
 					mk(EBinop("==", mk(EIdent(tmp),pmin(e1),pmax(e1)), mk(EIdent("null"),pmin(e1),pmax(e1)))),
 					mk(EIdent("null"),pmin(e1),pmax(e1)),
+					(eOp != null && eOp.length == 0) ? mk(ECall(mk(EField(mk(EIdent(tmp),pmin(e1),pmax(e1)),field),pmin(e1)),parseExprList(TPClose)),pmin(e1)) :
 					mk(EField(mk(EIdent(tmp),pmin(e1),pmax(e1)),field),pmin(e1))
 				))
 			]),pmin(e1));
-
-			if ( maybe(TPOpen) ) {
-				e = mk(EBlock([
-					mk(EVar(tmp, null, e1), pmin(e1), pmax(e1)),
-					mk(ETernary(
-						mk(EBinop("==", mk(EIdent(tmp),pmin(e1),pmax(e1)), mk(EIdent("null"),pmin(e1),pmax(e1)))),
-						mk(EIdent("null"),pmin(e1),pmax(e1)),
-						mk(ECall(mk(EField(mk(EIdent(tmp),pmin(e1),pmax(e1)),field),pmin(e1)),parseExprList(TPClose)),pmin(e1))
-					))
-				]),pmin(e1));
-			}
 
 			return parseExprNext(e);
 		case TPOpen:


### PR DESCRIPTION
## Description

Basically adds support for doing stuff like `obj?.x = True...`. This would grant you a compile error in Haxe 4 but doesn't in 5 so why not :shrug: 
The way it works is that `?.` basically becomes a ternary except it assigns the field inside its block.

Shoutout to Keoiki for the idea.
<img width="634" height="284" alt="image" src="https://github.com/user-attachments/assets/64240fc5-38d7-4379-86cc-28c6b6d6e8d1" />
