### PR TITLE
[BUGFIX] Fix finals not being considered as finals inside functions

### DIFF
--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -606,7 +606,7 @@ class Parser {
 				if( semic ) push(TSemicolon);
 			}
 			mk(EIf(cond,e1,e2),p1,(e2 == null) ? tokenMax : pmax(e2));
-		case "var", "final":
+		case "var":
 			var ident = getIdent();
 			var tk = token();
 			var t = null;


### PR DESCRIPTION
Basically fixes this
```
function foo()
{
    final test = 0;
    trace(test); // Outputs 0.
    test = 1;
    trace(test); // Outputs 1.
}
```
This was caused due to a commit in the upstream hscript repo that basically made finals get parsed as regular vars