### PR TITLE
[Fix] Move operation priority for `is` above other logic operators to match real Haxe behavior.

### DIFF
--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -117,6 +117,7 @@ class Parser
       ["+", "-"],
       ["<<", ">>", ">>>"],
       ["|", "&", "^"],
+      ["is"],
       ["==", "!=", ">", "<", ">=", "<="],
       ["..."],
       ["&&"],
@@ -139,7 +140,7 @@ class Parser
         "=>"
       ],
       ["->"],
-      ["in", "is"]
+      ["in"]
     ];
     opPriority = new Map();
     opRightAssoc = new Map();
@@ -147,7 +148,7 @@ class Parser
       for (x in priorities[i])
       {
         opPriority.set(x, i);
-        if (i == 10) opRightAssoc.set(x, true);
+        if (i == 11) opRightAssoc.set(x, true);
       }
     for (x in ["!", "++", "--", "~"]) // unary "-" handled in parser directly!
       opPriority.set(x, x == "++" || x == "--" ? -1 : -2);


### PR DESCRIPTION
This PR moves the priority set for `is` above the other logic operators. Which now matches the behavior of real Haxe:

TryHaxe example: https://try.haxe.org/#8BF6C561

Before this would happen:

<img width="715" height="396" alt="image" src="https://github.com/user-attachments/assets/84f5d374-1f4e-4aca-a9a1-5c781779ff08" />

Now it works just like in the haxe example:

<img width="742" height="468" alt="image" src="https://github.com/user-attachments/assets/d8c51954-091a-49a7-af3a-9b5aa0c206a1" />

<img width="1223" height="397" alt="image" src="https://github.com/user-attachments/assets/8ddd29de-aad2-48e2-8ea7-0cf065d09fa9" />
