### PR TITLE
[ENHANCEMENT] Allow interfaces to be parsed and no longer throw errors when they exist in scripts.

### DIFF
--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -147,6 +147,7 @@ ECustom(msg:String);
   DClass(c:ClassDecl);
   DTypedef(c:TypeDecl);
   DEnum(e:EnumDecl);
+  DInterface(e:InterfaceDecl);
 }
 
 typedef ModuleType =
@@ -188,6 +189,14 @@ typedef TypeDecl =
 {
   > ModuleType,
   var t:CType;
+}
+
+typedef InterfaceDecl =
+{
+  > ModuleType,
+  var extend:Array<CType>;
+  var fields:Array<FieldDecl>;
+  var isExtern:Bool;
 }
 
 typedef FieldDecl =

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -1458,6 +1458,39 @@ class Parser
             name: name,
             fields: fields
           });
+      case "interface":
+        var name = getIdent();
+        var params = parseParams();
+        var extend = [];
+
+        while (true)
+        {
+          var t = token();
+          switch (t)
+          {
+            case TId("extends"):
+              extend.push(parseType());
+            default:
+              push(t);
+              break;
+          }
+        }
+
+        var fields = [];
+        ensure(TBrOpen);
+        while (!maybe(TBrClose))
+          fields.push(parseInterfaceField());
+
+        return DInterface(
+          {
+            name: name,
+            meta: meta,
+            params: params,
+            isPrivate: isPrivate,
+            extend: extend,
+            fields: fields,
+            isExtern: isExtern,
+          });
       default:
         unexpected(TId(ident));
     }
@@ -1535,6 +1568,85 @@ class Parser
                 set: set,
                 type: type,
                 expr: expr,
+                isfinal: (id == "final")
+              }),
+          };
+        default:
+          unexpected(TId(id));
+          break;
+      }
+    }
+    return null;
+  }
+
+  function parseInterfaceField():FieldDecl
+  {
+    var meta = parseMetadata();
+    var access = [];
+    while (true)
+    {
+      var id = getIdent();
+      switch (id)
+      {
+        case "public":
+          access.push(APublic);
+        case "private":
+          access.push(APrivate);
+        case "static":
+          access.push(AStatic);
+        case "function":
+          var name = getIdent();
+          ensure(TPOpen);
+          var args = parseFunctionArgs();
+          var ret = null;
+          if (allowTypes)
+          {
+            var tk = token();
+            if (tk != TDoubleDot) push(tk);
+            else
+              ret = parseType();
+          }
+          ensure(TSemicolon);
+          return {
+            name: name,
+            meta: meta,
+            access: access,
+            kind: KFunction(
+              {
+                args: args,
+                expr: null,
+                ret: ret,
+              }),
+          };
+        case "var", "final":
+          var name = getIdent();
+          var get = null, set = null;
+          if (maybe(TPOpen))
+          {
+            get = getIdent();
+            ensure(TComma);
+            set = getIdent();
+            ensure(TPClose);
+          }
+          var type = maybe(TDoubleDot) ? parseType() : null;
+
+          if (type != null && type.match(CTAnon(_)))
+          {
+            maybe(TSemicolon);
+          }
+          else
+            ensure(TSemicolon);
+
+          return {
+            name: name,
+            meta: meta,
+            access: access,
+            kind: KVar(
+              {
+                get: get,
+                set: set,
+                type: type,
+                expr: null,
                 isfinal: (id == "final")
               }),
           };


### PR DESCRIPTION
This PR allows interfaces to be parsed and not just throw errors, which would make the whole script no longer work, even when working classes are inside. 

For now this is just allowing people to add interfaces without getting errors if they have them in their code structure alongside classes/enums etc.

**Now**

<img width="720" height="725" alt="image" src="https://github.com/user-attachments/assets/a6f69ab0-e00b-4a69-b84d-8e5af66c5496" />

**Before this would be shown**

<img width="990" height="577" alt="image" src="https://github.com/user-attachments/assets/f762380c-eb35-4cbd-aa58-4851c436d656" />

Since hscript would return `unexpected(TId(ident));`