### PR TITLE
[ENHANCEMENT] Add optional and default argument values parsing for lambdas.

### DIFF
--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -554,9 +554,17 @@ class Parser
   {
     while (true)
     {
-      var id = getIdent();
-      var t = maybe(TDoubleDot) ? parseType() : null;
-      args.push({name: id, t: t});
+      var arg:Argument = {name: null};
+      if (maybe(TQuestion)) arg.opt = true;
+      arg.name = getIdent();
+
+      if (allowTypes)
+      {
+        if (maybe(TDoubleDot)) arg.t = parseType();
+        if (maybe(TOp("="))) arg.value = parseExpr();
+      }
+      args.push(arg);
+
       var tk = token();
       switch (tk)
       {


### PR DESCRIPTION
This PR adds parsing for optional arguments and default argument values in lambdas, which threw errors before, as seen in this image:

<img width="991" height="317" alt="image" src="https://github.com/user-attachments/assets/d1d59629-78b1-4d9a-9372-3f2359cb6712" />