### PR TITLE
[ENHANCEMENT] Add extensions and optional fields parsing for typedefs.

### DIFF
--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -187,6 +187,7 @@ typedef EnumArgDecl =
 typedef TypeDecl =
 {
   > ModuleType,
+  var extensions:Array<CType>;
   var t:CType;
 }
 

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -1185,16 +1185,31 @@ class Parser
           {
             case TBrClose: break;
             case TId("var"), TId("final"):
+              var isOpt = maybe(TQuestion);
               var name = getIdent();
               ensure(TDoubleDot);
+              var type = parseType();
+              if (isOpt) type = CTOpt(type);
               if (t.match(TId("final")))
               {
                 if (meta == null) meta = [];
                 meta.push({name: ":final", params: []});
               }
-              fields.push({name: name, t: parseType(), meta: meta});
+              fields.push({name: name, t: type, meta: meta});
               meta = null;
               ensure(TSemicolon);
+            case TQuestion:
+              var name = getIdent();
+              ensure(TDoubleDot);
+              fields.push({name: name, t: CTOpt(parseType()), meta: meta});
+              meta = null;
+              t = token();
+              switch (t)
+              {
+                case TComma:
+                case TBrClose: break;
+                default: unexpected(t);
+              }
             case TId(name):
               ensure(TDoubleDot);
               fields.push({name: name, t: parseType(), meta: meta});
@@ -1433,6 +1448,18 @@ class Parser
         var name = getIdent();
         var params = parseParams();
         ensureToken(TOp("="));
+
+        var extensions = [];
+        if (maybe(TBrOpen))
+        {
+          while (maybe(TOp(">")))
+          {
+            extensions.push(parseType());
+            maybe(TComma);
+          }
+          push(TBrOpen);
+        }
+
         var t = parseType();
         return DTypedef(
           {
@@ -1440,6 +1467,7 @@ class Parser
             meta: meta,
             params: params,
             isPrivate: isPrivate,
+            extensions: extensions,
             t: t,
           });
       case "enum":


### PR DESCRIPTION
This PR adds correct parsing for optional and extensions in typedefs.

For example this snippet:
```haxe
typedef TestTypedef = {
	var id:Int;
	var data:T;
	var ?version:Float;
}

typedef ExtendedTypedef = {
	> TestTypedef,
	var description:String;
}
```

The hscript parser would complain (images below) about the unexpected `>` and `?` symbols before, but now it parses correctly the extensions and optional fields like `version`.

<img width="996" height="38" alt="image" src="https://github.com/user-attachments/assets/45bb18a8-97a6-4eae-a9ba-79e9ebc6e5ab" />

<img width="1010" height="37" alt="image" src="https://github.com/user-attachments/assets/dc5c1ac9-3994-45a0-ac6c-6d1946c3af3a" />
